### PR TITLE
use -a to define plugin

### DIFF
--- a/manifests/certonly.pp
+++ b/manifests/certonly.pp
@@ -22,7 +22,7 @@ define letsencrypt::certonly (
   Optional[Array[String]]                 $additional_args  = undef,
 ) {
 
-  $command = inline_template('<%= @letsencrypt_path %>/letsencrypt-auto certonly --<%= @plugin %> -d <%= @domains.join(" -d ")%><% if @additional_args %> <%= @additional_args.join(" ") %><%end%>')
+  $command = inline_template('<%= @letsencrypt_path %>/letsencrypt-auto certonly -a <%= @plugin %> -d <%= @domains.join(" -d ")%><% if @additional_args %> <%= @additional_args.join(" ") %><%end%>')
   $live_path = inline_template('/etc/letsencrypt/live/<%= @domains.first %>/cert.pem')
 
   exec { "letsencrypt certonly ${title}":

--- a/spec/defines/letsencrypt_certonly_spec.rb
+++ b/spec/defines/letsencrypt_certonly_spec.rb
@@ -8,25 +8,25 @@ describe 'letsencrypt::certonly' do
         let(:title) { 'foo.example.com' }
         it { is_expected.to contain_exec('letsencrypt certonly foo.example.com') }
         it { is_expected.to contain_exec('letsencrypt certonly foo.example.com').with_creates '/etc/letsencrypt/live/foo.example.com/cert.pem' }
-        it { is_expected.to contain_exec('letsencrypt certonly foo.example.com').with_command '/opt/letsencrypt/letsencrypt-auto certonly --standalone -d foo.example.com' }
+        it { is_expected.to contain_exec('letsencrypt certonly foo.example.com').with_command '/opt/letsencrypt/letsencrypt-auto certonly -a standalone -d foo.example.com' }
       end
 
       context 'with multiple domains' do
         let(:title) { 'foo' }
         let(:params) { { domains: ['foo.example.com', 'bar.example.com'] } }
-        it { is_expected.to contain_exec('letsencrypt certonly foo').with_command '/opt/letsencrypt/letsencrypt-auto certonly --standalone -d foo.example.com -d bar.example.com' }
+        it { is_expected.to contain_exec('letsencrypt certonly foo').with_command '/opt/letsencrypt/letsencrypt-auto certonly -a standalone -d foo.example.com -d bar.example.com' }
       end
 
       context 'with custom path' do
         let(:title) { 'foo.example.com' }
         let(:params) { { letsencrypt_path: '/usr/lib/letsencrypt' } }
-        it { is_expected.to contain_exec('letsencrypt certonly foo.example.com').with_command '/usr/lib/letsencrypt/letsencrypt-auto certonly --standalone -d foo.example.com' }
+        it { is_expected.to contain_exec('letsencrypt certonly foo.example.com').with_command '/usr/lib/letsencrypt/letsencrypt-auto certonly -a standalone -d foo.example.com' }
       end
 
       context 'with custom plugin' do
         let(:title) { 'foo.example.com' }
         let(:params) { { plugin: 'apache' } }
-        it { is_expected.to contain_exec('letsencrypt certonly foo.example.com').with_command '/opt/letsencrypt/letsencrypt-auto certonly --apache -d foo.example.com' }
+        it { is_expected.to contain_exec('letsencrypt certonly foo.example.com').with_command '/opt/letsencrypt/letsencrypt-auto certonly -a apache -d foo.example.com' }
       end
 
       context 'with invalid plugin' do
@@ -38,7 +38,7 @@ describe 'letsencrypt::certonly' do
       context 'when specifying additional arguments' do
         let(:title) { 'foo.example.com' }
         let(:params) { { additional_args: ['--foo bar', '--baz quux'] } }
-        it { is_expected.to contain_exec('letsencrypt certonly foo.example.com').with_command '/opt/letsencrypt/letsencrypt-auto certonly --standalone -d foo.example.com --foo bar --baz quux' }
+        it { is_expected.to contain_exec('letsencrypt certonly foo.example.com').with_command '/opt/letsencrypt/letsencrypt-auto certonly -a standalone -d foo.example.com --foo bar --baz quux' }
       end
     end
   end


### PR DESCRIPTION
This commit changes the call to letsencrypt-auto to use the parameter -a
to choose the plugin used to deploy the certificates.

To quote an example from the beta invite:
./letsencrypt-auto certonly -a standalone \
  -d example.com -d www.example.com