### PR TITLE
Install LE package on EL7, Ubuntu 16.04 and Debian 9+

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,5 +1,8 @@
 fixtures:
   repositories:
+    epel:
+      repo: 'https://github.com/stahnma/puppet-module-epel.git'
+      ref: '1.2.2'
     inifile:
       repo: 'https://github.com/puppetlabs/puppetlabs-inifile.git'
       ref: '1.4.2'

--- a/README.md
+++ b/README.md
@@ -7,6 +7,15 @@ This module installs the Let's Encrypt client from source and allows you to requ
 This module requires Puppet >= 4.0. and is currently only written to work on
 Debian and RedHat based operating systems.
 
+## Dependencies
+
+On EL (Red Hat, CentOS etc.) systems, the EPEL repository needs to be enabled
+for the Let's Encrypt client package.
+
+The module can integrate with [stahnma/epel](https://forge.puppetlabs.com/stahnma/epel)
+to set up the repo by setting the `configure_epel` parameter to `true` and
+installing the module.
+
 ## Usage
 
 To install the Let's Encrypt client with the default configuration settings you
@@ -15,6 +24,15 @@ must provide your email address to register with the Let's Encrypt servers:
 ```puppet
 class { ::letsencrypt:
   email => 'foo@example.com',
+}
+```
+
+If using EL7 without EPEL-preconfigured, add `configure_epel`:
+
+```puppet
+class { ::letsencrypt:
+  configure_epel => true,
+  email          => 'foo@example.com',
 }
 ```
 

--- a/manifests/certonly.pp
+++ b/manifests/certonly.pp
@@ -14,8 +14,8 @@
 #   Required if using `plugin => 'webroot'`. If `domains` and
 #   `webroot_paths` are not the same length, `webroot_paths`
 #   will cycle to make up the difference.
-# [*letsencrypt_path*]
-#   The path to the letsencrypt installation.
+# [*letsencrypt_command*]
+#   Command to run letsencrypt
 # [*additional_args*]
 #   An array of additional command line arguments to pass to the
 #   `letsencrypt-auto` command.
@@ -24,15 +24,15 @@
 #   Runs daily but only renews if near expiration, e.g. within 10 days. 
 #
 define letsencrypt::certonly (
-  Array[String]                           $domains          = [$title],
-  Enum['apache', 'standalone', 'webroot'] $plugin           = 'standalone',
-  Optional[Array[String]]                 $webroot_paths    = undef,
-  String                                  $letsencrypt_path = $letsencrypt::path,
-  Optional[Array[String]]                 $additional_args  = undef,
-  Boolean                                 $manage_cron      = false,
+  Array[String]                           $domains             = [$title],
+  Enum['apache', 'standalone', 'webroot'] $plugin              = 'standalone',
+  Optional[Array[String]]                 $webroot_paths       = undef,
+  String                                  $letsencrypt_command = $letsencrypt::command,
+  Optional[Array[String]]                 $additional_args     = undef,
+  Boolean                                 $manage_cron         = false,
 ) {
 
-  $command_start = "${letsencrypt_path}/letsencrypt-auto --agree-tos certonly -a ${plugin} "
+  $command_start = "${letsencrypt_command} --agree-tos certonly -a ${plugin} "
   $command_domains = $plugin ? {
     'webroot' => inline_template('<%= @domains.zip(@webroot_paths.cycle).map { |domain| "--webroot-path #{domain[1]} -d #{domain[0]}"}.join(" ") %>'),
     default   => inline_template('-d <%= @domains.join(" -d ")%>'),

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -20,30 +20,41 @@
 # [*manage_config*]
 #   A feature flag to toggle the management of the letsencrypt configuration
 #   file.
+# [*manage_install*]
+#   A feature flag to toggle the management of the letsencrypt client
+#   installation.
 # [*manage_dependencies*]
 #   A feature flag to toggle the management of the letsencrypt dependencies.
+# [*install_method*]
+#   Method to install the letsencrypt client, either package or vcs.
 # [*agree_tos*]
 #   A flag to agree to the Let's Encrypt Terms of Service.
 # [*unsafe_registration*]
 #   A flag to allow using the 'register-unsafely-without-email' flag.
 #
 class letsencrypt (
-  Optional[String]   $email               = undef,
-  String             $path                = $letsencrypt::params::path,
-  String             $repo                = $letsencrypt::params::repo,
-  String             $version             = $letsencrypt::params::version,
-  String             $config_file         = $letsencrypt::params::config_file,
-  Hash[String, Any]  $config              = $letsencrypt::params::config,
-  Boolean            $manage_config       = $letsencrypt::params::manage_config,
-  Boolean            $manage_dependencies = $letsencrypt::params::manage_dependencies,
-  Boolean            $agree_tos           = $letsencrypt::params::agree_tos,
-  Boolean            $unsafe_registration = $letsencrypt::params::unsafe_registration,
+  Optional[String]       $email               = undef,
+  String                 $path                = $letsencrypt::params::path,
+  String                 $repo                = $letsencrypt::params::repo,
+  String                 $version             = $letsencrypt::params::version,
+  String                 $config_file         = $letsencrypt::params::config_file,
+  Hash[String, Any]      $config              = $letsencrypt::params::config,
+  Boolean                $manage_config       = $letsencrypt::params::manage_config,
+  Boolean                $manage_install      = $letsencrypt::params::manage_install,
+  Boolean                $manage_dependencies = $letsencrypt::params::manage_dependencies,
+  Enum['package', 'vcs'] $install_method      = $letsencrypt::install_method,
+  Boolean                $agree_tos           = $letsencrypt::params::agree_tos,
+  Boolean                $unsafe_registration = $letsencrypt::params::unsafe_registration,
 ) inherits letsencrypt::params {
 
-  if $manage_dependencies {
-    $dependencies = ['python', 'git']
-    ensure_packages($dependencies)
-    Package[$dependencies] -> Vcsrepo[$path]
+  if $manage_install {
+    contain letsencrypt::install
+    Class['letsencrypt::install'] ~> Exec['initialize letsencrypt']
+  }
+
+  $command = $install_method ? {
+    'package' => 'letsencrypt',
+    'vcs'     => "${path}/letsencrypt-auto",
   }
 
   if $manage_config {
@@ -51,16 +62,9 @@ class letsencrypt (
     Class['letsencrypt::config'] -> Exec['initialize letsencrypt']
   }
 
-  vcsrepo { $path:
-    ensure   => present,
-    provider => git,
-    source   => $repo,
-    revision => $version,
-    notify   => Exec['initialize letsencrypt'],
-  }
-
   exec { 'initialize letsencrypt':
-    command     => "${path}/letsencrypt-auto -h",
+    command     => "${command} -h",
+    path        => $::path,
     refreshonly => true,
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -25,6 +25,9 @@
 #   installation.
 # [*manage_dependencies*]
 #   A feature flag to toggle the management of the letsencrypt dependencies.
+# [*configure_epel*]
+#   A feature flag to include the 'epel' class and depend on it for package
+#   installation.
 # [*install_method*]
 #   Method to install the letsencrypt client, either package or vcs.
 # [*agree_tos*]
@@ -42,6 +45,7 @@ class letsencrypt (
   Boolean                $manage_config       = $letsencrypt::params::manage_config,
   Boolean                $manage_install      = $letsencrypt::params::manage_install,
   Boolean                $manage_dependencies = $letsencrypt::params::manage_dependencies,
+  Boolean                $configure_epel      = $letsencrypt::params::configure_epel,
   Enum['package', 'vcs'] $install_method      = $letsencrypt::install_method,
   Boolean                $agree_tos           = $letsencrypt::params::agree_tos,
   Boolean                $unsafe_registration = $letsencrypt::params::unsafe_registration,

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -1,0 +1,48 @@
+# == Class: letsencrypt::install
+#
+#   This class installs the Let's Encrypt client.  This is a private class.
+#
+# === Parameters:
+#
+# [*manage_install*]
+#   A feature flag to toggle the management of the letsencrypt client
+#   installation.
+# [*manage_dependencies*]
+#   A feature flag to toggle the management of the letsencrypt dependencies.
+# [*install_method*]
+#   Method to install the letsencrypt client, either package or vcs.
+# [*path*]
+#   The path to the letsencrypt installation.
+# [*repo*]
+#   A Git URL to install the Let's encrypt client from.
+# [*version*]
+#   The Git ref (tag, sha, branch) to check out when installing the client.
+#
+class letsencrypt::install (
+  Boolean                $manage_install      = $letsencrypt::manage_install,
+  Boolean                $manage_dependencies = $letsencrypt::manage_dependencies,
+  Enum['package', 'vcs'] $install_method      = $letsencrypt::install_method,
+  String                 $path                = $letsencrypt::path,
+  String                 $repo                = $letsencrypt::repo,
+  String                 $version             = $letsencrypt::version,
+) {
+
+  if $install_method == 'vcs' {
+    if $manage_dependencies {
+      $dependencies = ['python', 'git']
+      ensure_packages($dependencies)
+      Package[$dependencies] -> Vcsrepo[$path]
+    }
+
+    vcsrepo { $path:
+      ensure   => present,
+      provider => git,
+      source   => $repo,
+      revision => $version,
+    }
+  } else {
+    package { 'letsencrypt':
+      ensure => installed,
+    }
+  }
+}

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -9,6 +9,9 @@
 #   installation.
 # [*manage_dependencies*]
 #   A feature flag to toggle the management of the letsencrypt dependencies.
+# [*configure_epel*]
+#   A feature flag to include the 'epel' class and depend on it for package
+#   installation.
 # [*install_method*]
 #   Method to install the letsencrypt client, either package or vcs.
 # [*path*]
@@ -21,6 +24,7 @@
 class letsencrypt::install (
   Boolean                $manage_install      = $letsencrypt::manage_install,
   Boolean                $manage_dependencies = $letsencrypt::manage_dependencies,
+  Boolean                $configure_epel      = $letsencrypt::configure_epel,
   Enum['package', 'vcs'] $install_method      = $letsencrypt::install_method,
   String                 $path                = $letsencrypt::path,
   String                 $repo                = $letsencrypt::repo,
@@ -43,6 +47,11 @@ class letsencrypt::install (
   } else {
     package { 'letsencrypt':
       ensure => installed,
+    }
+
+    if $configure_epel {
+      include ::epel
+      Class['epel'] -> Package['letsencrypt']
     }
   }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -7,6 +7,7 @@ class letsencrypt::params {
   $agree_tos           = true
   $unsafe_registration = false
   $manage_config       = true
+  $manage_install      = true
   $manage_dependencies = true
   $config_file         = '/etc/letsencrypt/cli.ini'
   $path                = '/opt/letsencrypt'
@@ -14,5 +15,32 @@ class letsencrypt::params {
   $version             = 'v0.1.0'
   $config              = {
     'server' => 'https://acme-v01.api.letsencrypt.org/directory',
+  }
+
+  case $::osfamily {
+    'Debian': {
+      case $::operatingsystem {
+        'Debian': {
+          if versioncmp($::operatingsystemrelease, '9') >= 0 {
+            $install_method = 'package'
+          } else {
+            $install_method = 'vcs'
+          }
+        }
+        'Ubuntu': {
+          if versioncmp($::operatingsystemrelease, '16.04') >= 0 {
+            $install_method = 'package'
+          } else {
+            $install_method = 'vcs'
+          }
+        }
+        default: {
+          $install_method = 'vcs'
+        }
+      }
+    }
+    'RedHat': {
+      $install_method = 'package'
+    }
   }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -9,6 +9,7 @@ class letsencrypt::params {
   $manage_config       = true
   $manage_install      = true
   $manage_dependencies = true
+  $configure_epel      = false
   $config_file         = '/etc/letsencrypt/cli.ini'
   $path                = '/opt/letsencrypt'
   $repo                = 'git://github.com/letsencrypt/letsencrypt.git'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,9 +1,4 @@
 class letsencrypt::params {
-
-  unless ($::osfamily == 'Debian') or ($::osfamily == 'RedHat') {
-    fail("The letsencrypt module does not support ${::osfamily}-based operating systems at this time.")
-  }
-
   $agree_tos           = true
   $unsafe_registration = false
   $manage_config       = true
@@ -18,30 +13,13 @@ class letsencrypt::params {
     'server' => 'https://acme-v01.api.letsencrypt.org/directory',
   }
 
-  case $::osfamily {
-    'Debian': {
-      case $::operatingsystem {
-        'Debian': {
-          if versioncmp($::operatingsystemrelease, '9') >= 0 {
-            $install_method = 'package'
-          } else {
-            $install_method = 'vcs'
-          }
-        }
-        'Ubuntu': {
-          if versioncmp($::operatingsystemrelease, '16.04') >= 0 {
-            $install_method = 'package'
-          } else {
-            $install_method = 'vcs'
-          }
-        }
-        default: {
-          $install_method = 'vcs'
-        }
-      }
-    }
-    'RedHat': {
-      $install_method = 'package'
-    }
+  if $::operatingsystem == 'Debian' and versioncmp($::operatingsystemrelease, '9') >= 0 {
+    $install_method = 'package'
+  } elsif $::operatingsystem == 'Ubuntu' and versioncmp($::operatingsystemrelease, '16.04') >= 0 {
+    $install_method = 'package'
+  } elsif $::osfamily == 'RedHat' {
+    $install_method = 'package'
+  } else {
+    $install_method = 'vcs'
   }
 }

--- a/spec/classes/letsencrypt_install_spec.rb
+++ b/spec/classes/letsencrypt_install_spec.rb
@@ -4,6 +4,7 @@ describe 'letsencrypt::install' do
   let(:params) { default_params.merge(additional_params) }
   let(:default_params) do
     {
+      configure_epel: false,
       manage_install: true,
       manage_dependencies: true,
       path: '/opt/letsencrypt',
@@ -24,6 +25,17 @@ describe 'letsencrypt::install' do
       is_expected.not_to contain_package('git')
 
       is_expected.to contain_package('letsencrypt').with_ensure('installed')
+    end
+
+    describe 'with configure_epel => true' do
+      let(:additional_params) { { install_method: 'package', configure_epel: true } }
+
+      it { is_expected.to compile }
+
+      it 'should contain the correct resources' do
+        is_expected.to contain_class('epel')
+        is_expected.to contain_package('letsencrypt').that_requires('Class[epel]')
+      end
     end
   end
 

--- a/spec/classes/letsencrypt_install_spec.rb
+++ b/spec/classes/letsencrypt_install_spec.rb
@@ -1,0 +1,69 @@
+require 'spec_helper'
+
+describe 'letsencrypt::install' do
+  let(:params) { default_params.merge(additional_params) }
+  let(:default_params) do
+    {
+      manage_install: true,
+      manage_dependencies: true,
+      path: '/opt/letsencrypt',
+      repo: 'git://github.com/letsencrypt/letsencrypt.git',
+      version: 'v0.1.0',
+    }
+  end
+  let(:additional_params) { { } }
+
+  describe 'with install_method => package' do
+    let(:additional_params) { { install_method: 'package' } }
+
+    it { is_expected.to compile }
+
+    it 'should contain the correct resources' do
+      is_expected.not_to contain_vcsrepo('/opt/letsencrypt')
+      is_expected.not_to contain_package('python')
+      is_expected.not_to contain_package('git')
+
+      is_expected.to contain_package('letsencrypt').with_ensure('installed')
+    end
+  end
+
+  describe 'with install_method => vcs' do
+    let(:additional_params) { { install_method: 'vcs' } }
+
+    it { is_expected.to compile }
+
+    it 'should contain the correct resources' do
+      is_expected.to contain_vcsrepo('/opt/letsencrypt').with({
+        source: 'git://github.com/letsencrypt/letsencrypt.git',
+        revision: 'v0.1.0'
+      })
+      is_expected.to contain_package('python')
+      is_expected.to contain_package('git')
+
+      is_expected.not_to contain_package('letsencrypt')
+    end
+
+    describe 'with custom path' do
+      let(:additional_params) { { install_method: 'vcs', path: '/usr/lib/letsencrypt' } }
+      it { is_expected.to contain_vcsrepo('/usr/lib/letsencrypt') }
+    end
+
+    describe 'with custom repo' do
+      let(:additional_params) { { install_method: 'vcs', repo: 'git://foo.com/letsencrypt.git' } }
+      it { is_expected.to contain_vcsrepo('/opt/letsencrypt').with_source('git://foo.com/letsencrypt.git') }
+    end
+
+    describe 'with custom version' do
+      let(:additional_params) { { install_method: 'vcs', version: 'foo' } }
+      it { is_expected.to contain_vcsrepo('/opt/letsencrypt').with_revision('foo') }
+    end
+
+    describe 'with manage_dependencies set to false' do
+      let(:additional_params) { { install_method: 'vcs', manage_dependencies: false } }
+      it 'should not contain the dependencies' do
+        is_expected.not_to contain_package('git')
+        is_expected.not_to contain_package('python')
+      end
+    end
+  end
+end

--- a/spec/classes/letsencrypt_spec.rb
+++ b/spec/classes/letsencrypt_spec.rb
@@ -103,10 +103,16 @@ describe 'letsencrypt' do
     end
   end
 
-  context 'on unsupported operating systems' do
-    let(:facts) { { osfamily: 'Darwin' } }
-    it 'should fail' do
-      is_expected.to raise_error Puppet::Error, /The letsencrypt module does not support Darwin/
+  context 'on unknown operating systems' do
+    let(:facts) { { osfamily: 'Darwin', path: '/usr/bin' } }
+    let(:params) { { email: 'foo@example.com' } }
+
+    describe 'with defaults' do
+      it { is_expected.to compile }
+
+      it 'should contain the correct resources' do
+        is_expected.to contain_class('letsencrypt::install').with(install_method: 'vcs')
+      end
     end
   end
 

--- a/spec/classes/letsencrypt_spec.rb
+++ b/spec/classes/letsencrypt_spec.rb
@@ -15,6 +15,7 @@ describe 'letsencrypt' do
 
           it 'should contain the correct resources' do
             is_expected.to contain_class('letsencrypt::install').with({
+              configure_epel: false,
               manage_install: true,
               manage_dependencies: true,
               repo: 'git://github.com/letsencrypt/letsencrypt.git',

--- a/spec/defines/letsencrypt_certonly_spec.rb
+++ b/spec/defines/letsencrypt_certonly_spec.rb
@@ -1,25 +1,25 @@
 describe 'letsencrypt::certonly' do
-  ['Debian', 'RedHat'].each do |osfamily|
+  {'Debian' => '9.0', 'RedHat' => '7.2'}.each do |osfamily, osversion|
     context "on #{osfamily} based operating systems" do
-      let(:facts) { { osfamily: osfamily } }
+      let(:facts) { { osfamily: osfamily, operatingsystem: osfamily, operatingsystemrelease: osversion, path: '/usr/bin' } }
       let(:pre_condition) { "class { letsencrypt: email => 'foo@example.com' }" }
 
       context 'with a single domain' do
         let(:title) { 'foo.example.com' }
         it { is_expected.to contain_exec('letsencrypt certonly foo.example.com') }
         it { is_expected.to contain_exec('letsencrypt certonly foo.example.com').with_creates '/etc/letsencrypt/live/foo.example.com/cert.pem' }
-        it { is_expected.to contain_exec('letsencrypt certonly foo.example.com').with_command '/opt/letsencrypt/letsencrypt-auto --agree-tos certonly -a standalone -d foo.example.com' }
+        it { is_expected.to contain_exec('letsencrypt certonly foo.example.com').with_command 'letsencrypt --agree-tos certonly -a standalone -d foo.example.com' }
       end
 
       context 'with multiple domains' do
         let(:title) { 'foo' }
         let(:params) { { domains: ['foo.example.com', 'bar.example.com'] } }
-        it { is_expected.to contain_exec('letsencrypt certonly foo').with_command '/opt/letsencrypt/letsencrypt-auto --agree-tos certonly -a standalone -d foo.example.com -d bar.example.com' }
+        it { is_expected.to contain_exec('letsencrypt certonly foo').with_command 'letsencrypt --agree-tos certonly -a standalone -d foo.example.com -d bar.example.com' }
       end
 
-      context 'with custom path' do
+      context 'with custom command' do
         let(:title) { 'foo.example.com' }
-        let(:params) { { letsencrypt_path: '/usr/lib/letsencrypt' } }
+        let(:params) { { letsencrypt_command: '/usr/lib/letsencrypt/letsencrypt-auto' } }
         it { is_expected.to contain_exec('letsencrypt certonly foo.example.com').with_command '/usr/lib/letsencrypt/letsencrypt-auto --agree-tos certonly -a standalone -d foo.example.com' }
       end
 
@@ -27,7 +27,7 @@ describe 'letsencrypt::certonly' do
         let(:title) { 'foo.example.com' }
         let(:params) { { plugin: 'webroot',
                          webroot_paths: ['/var/www/foo'] } }
-        it { is_expected.to contain_exec('letsencrypt certonly foo.example.com').with_command '/opt/letsencrypt/letsencrypt-auto --agree-tos certonly -a webroot --webroot-path /var/www/foo -d foo.example.com' }
+        it { is_expected.to contain_exec('letsencrypt certonly foo.example.com').with_command 'letsencrypt --agree-tos certonly -a webroot --webroot-path /var/www/foo -d foo.example.com' }
       end
 
       context 'with webroot plugin and multiple domains' do
@@ -35,7 +35,7 @@ describe 'letsencrypt::certonly' do
         let(:params) { { domains: ['foo.example.com', 'bar.example.com'],
                          plugin: 'webroot',
                          webroot_paths: ['/var/www/foo', '/var/www/bar'] } }
-        it { is_expected.to contain_exec('letsencrypt certonly foo').with_command '/opt/letsencrypt/letsencrypt-auto --agree-tos certonly -a webroot --webroot-path /var/www/foo -d foo.example.com --webroot-path /var/www/bar -d bar.example.com' }
+        it { is_expected.to contain_exec('letsencrypt certonly foo').with_command 'letsencrypt --agree-tos certonly -a webroot --webroot-path /var/www/foo -d foo.example.com --webroot-path /var/www/bar -d bar.example.com' }
       end
 
       context 'with webroot plugin, one webroot, and multiple domains' do
@@ -43,20 +43,20 @@ describe 'letsencrypt::certonly' do
         let(:params) { { domains: ['foo.example.com', 'bar.example.com'],
                          plugin: 'webroot',
                          webroot_paths: ['/var/www/foo'] } }
-        it { is_expected.to contain_exec('letsencrypt certonly foo').with_command '/opt/letsencrypt/letsencrypt-auto --agree-tos certonly -a webroot --webroot-path /var/www/foo -d foo.example.com --webroot-path /var/www/foo -d bar.example.com' }
+        it { is_expected.to contain_exec('letsencrypt certonly foo').with_command 'letsencrypt --agree-tos certonly -a webroot --webroot-path /var/www/foo -d foo.example.com --webroot-path /var/www/foo -d bar.example.com' }
       end
 
       context 'with custom plugin' do
         let(:title) { 'foo.example.com' }
         let(:params) { { plugin: 'apache' } }
-        it { is_expected.to contain_exec('letsencrypt certonly foo.example.com').with_command '/opt/letsencrypt/letsencrypt-auto --agree-tos certonly -a apache -d foo.example.com' }
+        it { is_expected.to contain_exec('letsencrypt certonly foo.example.com').with_command 'letsencrypt --agree-tos certonly -a apache -d foo.example.com' }
       end
 
       context 'with custom plugin and manage cron' do
         let(:title) { 'foo.example.com' }
         let(:params) { { plugin: 'apache',
                          manage_cron: true } }
-        it { is_expected.to contain_cron('letsencrypt renew cron foo.example.com').with_command '/opt/letsencrypt/letsencrypt-auto --agree-tos certonly -a apache --keep-until-expiring -d foo.example.com' }
+        it { is_expected.to contain_cron('letsencrypt renew cron foo.example.com').with_command 'letsencrypt --agree-tos certonly -a apache --keep-until-expiring -d foo.example.com' }
       end
 
       context 'with invalid plugin' do
@@ -68,7 +68,7 @@ describe 'letsencrypt::certonly' do
       context 'when specifying additional arguments' do
         let(:title) { 'foo.example.com' }
         let(:params) { { additional_args: ['--foo bar', '--baz quux'] } }
-        it { is_expected.to contain_exec('letsencrypt certonly foo.example.com').with_command '/opt/letsencrypt/letsencrypt-auto --agree-tos certonly -a standalone -d foo.example.com --foo bar --baz quux' }
+        it { is_expected.to contain_exec('letsencrypt certonly foo.example.com').with_command 'letsencrypt --agree-tos certonly -a standalone -d foo.example.com --foo bar --baz quux' }
       end
     end
   end


### PR DESCRIPTION
A new $install_method parameter to letsencrypt allows selection between
a git/VCS based installation and a package based installation.  It
defaults to packages on newer OSes where they're available - in EPEL7,
and upcoming Debian and Ubuntu releases.

Installation has been moved into letsencrypt::install and the LE command
itself is determined by the installation method.