### PR TITLE
Change Puppet 4 specifics to support 3.4+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,8 @@ rvm:
   - 2.1
 script: bundle exec rake test
 env:
+  - PUPPET_VERSION="~> 3.4.0"
+  - PUPPET_VERSION="~> 3.4"
   - PUPPET_VERSION="~> 4.0.0"
   - PUPPET_VERSION="~> 4.1.0"
   - PUPPET_VERSION="~> 4.2.0"

--- a/Gemfile
+++ b/Gemfile
@@ -2,13 +2,15 @@ source 'https://rubygems.org'
 
 group :test do
   gem 'rake'
-  gem 'puppet', ENV['PUPPET_VERSION'] || '~> 4.3.0'
+  gem 'puppet', ENV['PUPPET_VERSION'] || ['>= 3.4', '< 5']
   gem 'puppet-lint'
   gem 'rspec-puppet'
   gem 'puppet-syntax'
   gem 'puppetlabs_spec_helper'
   gem 'metadata-json-lint'
-  gem 'puppet-strings', git: 'git://github.com/puppetlabs/puppetlabs-strings.git'
+  unless ENV['PUPPET_VERSION'] == '~> 3.4.0'
+    gem 'puppet-strings', git: 'git://github.com/puppetlabs/puppetlabs-strings.git'
+  end
   gem 'puppet-lint-absolute_classname-check'
   gem 'puppet-lint-alias-check'
   gem 'puppet-lint-empty_string-check'

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This module installs the Let's Encrypt client from source and allows you to requ
 
 ## Support
 
-This module requires Puppet >= 4.0. and is currently only written to work on
+This module requires Puppet >= 3.4. and is currently only written to work on
 Debian and RedHat based operating systems.
 
 ## Dependencies

--- a/Rakefile
+++ b/Rakefile
@@ -1,7 +1,6 @@
 require 'puppetlabs_spec_helper/rake_tasks'
 require 'puppet-lint/tasks/puppet-lint'
 require 'puppet-syntax/tasks/puppet-syntax'
-require 'puppet-strings/rake_tasks'
 require 'rubocop/rake_task'
 
 RuboCop::RakeTask.new
@@ -10,6 +9,7 @@ RuboCop::RakeTask.new
 # on Travis with --without development
 begin
   require 'puppet_blacksmith/rake_tasks'
+  require 'puppet-strings/rake_tasks'
 rescue LoadError
 end
 

--- a/manifests/certonly.pp
+++ b/manifests/certonly.pp
@@ -24,13 +24,23 @@
 #   Runs daily but only renews if near expiration, e.g. within 10 days. 
 #
 define letsencrypt::certonly (
-  Array[String]                           $domains             = [$title],
-  Enum['apache', 'standalone', 'webroot'] $plugin              = 'standalone',
-  Optional[Array[String]]                 $webroot_paths       = undef,
-  String                                  $letsencrypt_command = $letsencrypt::command,
-  Optional[Array[String]]                 $additional_args     = undef,
-  Boolean                                 $manage_cron         = false,
+  $domains             = [$title],
+  $plugin              = 'standalone',
+  $webroot_paths       = undef,
+  $letsencrypt_command = $letsencrypt::command,
+  $additional_args     = undef,
+  $manage_cron         = false,
 ) {
+  validate_array($domains)
+  validate_re($plugin, ['^apache$', '^standalone$', '^webroot$'])
+  if $webroot_paths {
+    validate_array($webroot_paths)
+  }
+  validate_string(letsencrypt_path)
+  if $additional_args {
+    validate_array($additional_args)
+  }
+  validate_bool($manage_cron)
 
   $command_start = "${letsencrypt_command} --agree-tos certonly -a ${plugin} "
   $command_domains = $plugin ? {

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -40,15 +40,7 @@ class letsencrypt::config (
     }
   }
 
-  $_config.each |$setting, $value| {
-    ini_setting { "${config_file} ${setting} ${value}":
-      ensure  => present,
-      path    => $config_file,
-      section => '',
-      setting => $setting,
-      value   => $value,
-      require => File['/etc/letsencrypt'],
-    }
-  }
+  $_config_joined = join_keys_to_values($_config, '=')
+  letsencrypt::config::ini { $_config_joined: }
 
 }

--- a/manifests/config/ini.pp
+++ b/manifests/config/ini.pp
@@ -1,0 +1,23 @@
+# == Define: letsencrypt::client::ini
+#
+#   This configures a single setting in the LE INI file. This is a private resource.
+#
+define letsencrypt::config::ini () {
+
+  assert_private()
+
+  $name_split = split($name, '=')
+  $setting = $name_split[0]
+  $value = $name_split[1]
+  $config_file = $::letsencrypt::config::config_file
+
+  ini_setting { "${config_file} ${setting} ${value}":
+    ensure  => present,
+    path    => $config_file,
+    section => '',
+    setting => $setting,
+    value   => $value,
+    require => File['/etc/letsencrypt'],
+  }
+
+}

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -36,20 +36,27 @@
 #   A flag to allow using the 'register-unsafely-without-email' flag.
 #
 class letsencrypt (
-  Optional[String]       $email               = undef,
-  String                 $path                = $letsencrypt::params::path,
-  String                 $repo                = $letsencrypt::params::repo,
-  String                 $version             = $letsencrypt::params::version,
-  String                 $config_file         = $letsencrypt::params::config_file,
-  Hash[String, Any]      $config              = $letsencrypt::params::config,
-  Boolean                $manage_config       = $letsencrypt::params::manage_config,
-  Boolean                $manage_install      = $letsencrypt::params::manage_install,
-  Boolean                $manage_dependencies = $letsencrypt::params::manage_dependencies,
-  Boolean                $configure_epel      = $letsencrypt::params::configure_epel,
-  Enum['package', 'vcs'] $install_method      = $letsencrypt::install_method,
-  Boolean                $agree_tos           = $letsencrypt::params::agree_tos,
-  Boolean                $unsafe_registration = $letsencrypt::params::unsafe_registration,
+  $email               = undef,
+  $path                = $letsencrypt::params::path,
+  $repo                = $letsencrypt::params::repo,
+  $version             = $letsencrypt::params::version,
+  $config_file         = $letsencrypt::params::config_file,
+  $config              = $letsencrypt::params::config,
+  $manage_config       = $letsencrypt::params::manage_config,
+  $manage_install      = $letsencrypt::params::manage_install,
+  $manage_dependencies = $letsencrypt::params::manage_dependencies,
+  $configure_epel      = $letsencrypt::params::configure_epel,
+  $install_method      = $letsencrypt::params::install_method,
+  $agree_tos           = $letsencrypt::params::agree_tos,
+  $unsafe_registration = $letsencrypt::params::unsafe_registration,
 ) inherits letsencrypt::params {
+  validate_string($path, $repo, $version, $config_file)
+  if $email {
+    validate_string($email)
+  }
+  validate_bool($manage_config, $manage_install, $manage_dependencies, $configure_epel, $agree_tos, $unsafe_registration)
+  validate_hash($config)
+  validate_re($install_method, ['^package$', '^vcs$'])
 
   if $manage_install {
     contain letsencrypt::install

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -22,14 +22,17 @@
 #   The Git ref (tag, sha, branch) to check out when installing the client.
 #
 class letsencrypt::install (
-  Boolean                $manage_install      = $letsencrypt::manage_install,
-  Boolean                $manage_dependencies = $letsencrypt::manage_dependencies,
-  Boolean                $configure_epel      = $letsencrypt::configure_epel,
-  Enum['package', 'vcs'] $install_method      = $letsencrypt::install_method,
-  String                 $path                = $letsencrypt::path,
-  String                 $repo                = $letsencrypt::repo,
-  String                 $version             = $letsencrypt::version,
+  $manage_install      = $letsencrypt::manage_install,
+  $manage_dependencies = $letsencrypt::manage_dependencies,
+  $configure_epel      = $letsencrypt::configure_epel,
+  $install_method      = $letsencrypt::install_method,
+  $path                = $letsencrypt::path,
+  $repo                = $letsencrypt::repo,
+  $version             = $letsencrypt::version,
 ) {
+  validate_bool($manage_install, $manage_dependencies, $configure_epel)
+  validate_re($install_method, ['^package$', '^vcs$'])
+  validate_string($path, $repo, $version)
 
   if $install_method == 'vcs' {
     if $manage_dependencies {

--- a/metadata.json
+++ b/metadata.json
@@ -43,7 +43,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 4.0.0"
+      "version_requirement": ">= 3.4.0"
     }
   ],
   "dependencies": [


### PR DESCRIPTION
Future/Puppet 4 parser specifics have been removed to support Puppet
3.x, though requiring a minimum of 3.4 for the contain() function.