### PR TITLE
Fix #16 by specifying VENV_PATH when running letsencrypt.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -42,6 +42,7 @@
 class letsencrypt (
   $email               = undef,
   $path                = $letsencrypt::params::path,
+  $venv_path           = $letsencrypt::params::venv_path,
   $repo                = $letsencrypt::params::repo,
   $version             = $letsencrypt::params::version,
   $package_ensure      = $letsencrypt::params::package_ensure,
@@ -81,6 +82,7 @@ class letsencrypt (
   exec { 'initialize letsencrypt':
     command     => "${command} -h",
     path        => $::path,
+    environment => ["VENV_PATH=${venv_path}"],
     refreshonly => true,
   }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -8,6 +8,7 @@ class letsencrypt::params {
   $package_ensure      = 'installed'
   $config_file         = '/etc/letsencrypt/cli.ini'
   $path                = '/opt/letsencrypt'
+  $venv_path           = '/opt/letsencrypt/.venv' # virtualenv path for vcs-installed letsencrypt
   $repo                = 'git://github.com/letsencrypt/letsencrypt.git'
   $version             = 'v0.4.0'
   $config              = {


### PR DESCRIPTION
Issue copy-paste from
https://github.com/danzilio/puppet-letsencrypt/issues/16

When you install letsencrypt using the VCS method, it will create a
virtualenv, which would normally be located in
~/.local/share/letsencrypt:

Excerpt from letsencrypt-auto:
```
XDG_DATA_HOME=${XDG_DATA_HOME:-~/.local/share}
VENV_NAME="letsencrypt"
VENV_PATH=${VENV_PATH:-"$XDG_DATA_HOME/$VENV_NAME"}
```
However, puppet exec's will not set $HOME, which will stop Debian's
/bin/sh, dash, from expanding ~, so it creates a literal '~' folder.