### PR TITLE
Feature: Allow running a command after successful cronjob.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 All notable changes to this project will be documented in this file. This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased][unreleased]
+- Ability to run commands after a successful cronjob-based renewal with the `cron_success_command` parameter.
 
 ## [1.0.0] - 2016-02-22
 ## Added

--- a/README.md
+++ b/README.md
@@ -89,6 +89,17 @@ letsencrypt::certonly { 'foo':
 }
 ```
 
+To automatically renew a certificate, you can pass the `manage_cron` parameter.
+You can optionally add a shell command to be run on success using the `cron_success_command` parameter.
+
+```puppet
+letsencrypt::certonly { 'foo':
+  domains => ['foo.example.com', 'bar.example.com'],
+  manage_cron => true,
+  cron_success_command => '/bin/systemctl reload nginx.service',
+}
+```
+
 ## Development
 
 1. Fork it

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -42,6 +42,7 @@
 class letsencrypt (
   $email               = undef,
   $path                = $letsencrypt::params::path,
+  $venv_path           = $letsencrypt::params::venv_path,
   $repo                = $letsencrypt::params::repo,
   $version             = $letsencrypt::params::version,
   $package_ensure      = $letsencrypt::params::package_ensure,
@@ -81,6 +82,7 @@ class letsencrypt (
   exec { 'initialize letsencrypt':
     command     => "${command} -h",
     path        => $::path,
+    environment => ["VENV_PATH=${venv_path}"],
     refreshonly => true,
   }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -8,6 +8,7 @@ class letsencrypt::params {
   $package_ensure      = 'installed'
   $config_file         = '/etc/letsencrypt/cli.ini'
   $path                = '/opt/letsencrypt'
+  $venv_path           = '/opt/letsencrypt/.venv' # virtualenv path for vcs-installed letsencrypt
   $repo                = 'git://github.com/letsencrypt/letsencrypt.git'
   $version             = 'v0.4.0'
   $config              = {

--- a/spec/defines/letsencrypt_certonly_spec.rb
+++ b/spec/defines/letsencrypt_certonly_spec.rb
@@ -59,6 +59,14 @@ describe 'letsencrypt::certonly' do
         it { is_expected.to contain_cron('letsencrypt renew cron foo.example.com').with_command 'letsencrypt --agree-tos certonly -a apache --keep-until-expiring -d foo.example.com' }
       end
 
+      context 'with custom plugin and manage cron and cron_success_command' do
+        let(:title) { 'foo.example.com' }
+        let(:params) { { plugin: 'apache',
+                         manage_cron: true,
+                         cron_success_command: "echo success" } }
+        it { is_expected.to contain_cron('letsencrypt renew cron foo.example.com').with_command 'letsencrypt --agree-tos certonly -a apache --keep-until-expiring -d foo.example.com && (echo success)' }
+      end
+
       context 'with invalid plugin' do
         let(:title) { 'foo.example.com' }
         let(:params) { { plugin: 'bad' } }


### PR DESCRIPTION
Using the `cron_success_cmd` parameter for `certonly`, you can
run commands when the renewal command was successful, e.g.
reload the webserver to use the renewed certs.

Not sure about letsencrypt return values, so the cmd might be
executed even if the cert is unchanged, doesn't matter for this
usecase though.


(This PR includes the bugfix for #16 for easy fast forward merging, assuming you want to merge the bugfix)