### PR TITLE
Added optional 'environment' parameter to init and certonly. Specced.

### DIFF
--- a/manifests/certonly.pp
+++ b/manifests/certonly.pp
@@ -19,6 +19,8 @@
 # [*additional_args*]
 #   An array of additional command line arguments to pass to the
 #   `letsencrypt-auto` command.
+# [*environment*]
+#   An optional array of environment variables (in addition to VENV_PATH).
 # [*manage_cron*]
 #   Boolean indicating whether or not to schedule cron job for renewal.
 #   Runs daily but only renews if near expiration, e.g. within 10 days.
@@ -29,6 +31,7 @@ define letsencrypt::certonly (
   $webroot_paths       = undef,
   $letsencrypt_command = $letsencrypt::command,
   $additional_args     = undef,
+  $environment         = [],
   $manage_cron         = false,
 ) {
   validate_array($domains)
@@ -55,7 +58,7 @@ define letsencrypt::certonly (
   exec { "letsencrypt certonly ${title}":
     command     => $command,
     path        => $::path,
-    environment => [$venv_path_var],
+    environment => concat([ $venv_path_var ], $environment),
     creates     => $live_path,
     require     => Class['letsencrypt'],
   }
@@ -66,7 +69,7 @@ define letsencrypt::certonly (
     $cron_minute = fqdn_rand(60, $title ) # 0 - 59, seed is title plus fqdn
     cron { "letsencrypt renew cron ${title}":
       command     => $renewcommand,
-      environment => $venv_path_var,
+      environment => concat([ $venv_path_var ], $environment),
       user        => root,
       hour        => $cron_hour,
       minute      => $cron_minute,

--- a/manifests/certonly.pp
+++ b/manifests/certonly.pp
@@ -43,6 +43,7 @@ define letsencrypt::certonly (
   if $additional_args {
     validate_array($additional_args)
   }
+  validate_array($environment)
   validate_bool($manage_cron)
 
   $command_start = "${letsencrypt_command} --agree-tos certonly -a ${plugin} "

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -9,6 +9,8 @@
 #   precedence over an 'email' setting defined in $config.
 # [*path*]
 #   The path to the letsencrypt installation.
+# [*environment*]
+#   An optional array of environment variables (in addition to VENV_PATH)
 # [*repo*]
 #   A Git URL to install the Let's encrypt client from.
 # [*version*]
@@ -43,6 +45,7 @@ class letsencrypt (
   $email               = undef,
   $path                = $letsencrypt::params::path,
   $venv_path           = $letsencrypt::params::venv_path,
+  $environment         = [],
   $repo                = $letsencrypt::params::repo,
   $version             = $letsencrypt::params::version,
   $package_ensure      = $letsencrypt::params::package_ensure,
@@ -88,7 +91,7 @@ class letsencrypt (
   exec { 'initialize letsencrypt':
     command     => "${command_init} -h",
     path        => $::path,
-    environment => ["VENV_PATH=${venv_path}"],
+    environment => concat([ "VENV_PATH=${venv_path}" ], $environment),
     refreshonly => true,
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -63,6 +63,7 @@ class letsencrypt (
   if $email {
     validate_string($email)
   }
+  validate_array($environment)
   validate_bool($manage_config, $manage_install, $manage_dependencies, $configure_epel, $agree_tos, $unsafe_registration)
   validate_hash($config)
   validate_re($install_method, ['^package$', '^vcs$'])

--- a/spec/classes/letsencrypt_spec.rb
+++ b/spec/classes/letsencrypt_spec.rb
@@ -35,6 +35,11 @@ describe 'letsencrypt' do
           it { is_expected.to contain_exec('initialize letsencrypt').with_command('/usr/lib/letsencrypt/letsencrypt-auto -h') }
         end
 
+        describe 'with custom environment variables' do
+          let(:additional_params) { { environment: [ 'FOO=bar', 'FIZZ=buzz' ] } }
+          it { is_expected.to contain_exec('initialize letsencrypt').with_environment([ 'VENV_PATH=/opt/letsencrypt/.venv', 'FOO=bar', 'FIZZ=buzz' ]) }
+        end
+
         describe 'with custom repo' do
           let(:additional_params) { { repo: 'git://foo.com/letsencrypt.git' } }
           it { is_expected.to contain_class('letsencrypt::install').with_repo('git://foo.com/letsencrypt.git') }

--- a/spec/defines/letsencrypt_certonly_spec.rb
+++ b/spec/defines/letsencrypt_certonly_spec.rb
@@ -70,6 +70,19 @@ describe 'letsencrypt::certonly' do
         let(:params) { { additional_args: ['--foo bar', '--baz quux'] } }
         it { is_expected.to contain_exec('letsencrypt certonly foo.example.com').with_command 'letsencrypt --agree-tos certonly -a standalone -d foo.example.com --foo bar --baz quux' }
       end
+
+      describe 'when specifying custom environment variables' do
+        let(:title) { 'foo.example.com' }
+        let(:params) { { environment: [ 'FOO=bar', 'FIZZ=buzz' ] } }
+        it { is_expected.to contain_exec('letsencrypt certonly foo.example.com').with_environment([ "VENV_PATH=/opt/letsencrypt/.venv", 'FOO=bar', 'FIZZ=buzz' ]) }
+      end
+
+      context 'with custom environment variables and manage cron' do
+        let(:title) { 'foo.example.com' }
+        let(:params) { { environment: [ 'FOO=bar', 'FIZZ=buzz' ], manage_cron: true } }
+
+        it { is_expected.to contain_cron('letsencrypt renew cron foo.example.com').with_environment([ "VENV_PATH=/opt/letsencrypt/.venv", 'FOO=bar', 'FIZZ=buzz' ]) }
+      end
     end
   end
 end


### PR DESCRIPTION
This concats any custom environment variables with those already set by the module. My own use-case is to set HTTP_PROXY and HTTPS_PROXY in order to use LetsEncrypt behind an outbound proxy.