### PR TITLE
Add a way to change package name and command

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -19,6 +19,12 @@
 # [*package_ensure*]
 #   The value passed to `ensure` when installing the client with the `package`
 #   method.
+# [*package_name*]
+#   Name of package and command to use when installing the client with the
+#   `package` method.
+# [*package_command*]
+#   Path or name for letsencrypt executable when installing the client with
+#   the `package` method. 
 # [*config_file*]
 #   The path to the configuration file for the letsencrypt cli.
 # [*config*]
@@ -48,7 +54,9 @@ class letsencrypt (
   $environment         = [],
   $repo                = $letsencrypt::params::repo,
   $version             = $letsencrypt::params::version,
+  $package_name        = $letsencrypt::params::package_name,
   $package_ensure      = $letsencrypt::params::package_ensure,
+  $package_command     = $letsencrypt::params::package_command,
   $config_file         = $letsencrypt::params::config_file,
   $config              = $letsencrypt::params::config,
   $manage_config       = $letsencrypt::params::manage_config,
@@ -59,7 +67,7 @@ class letsencrypt (
   $agree_tos           = $letsencrypt::params::agree_tos,
   $unsafe_registration = $letsencrypt::params::unsafe_registration,
 ) inherits letsencrypt::params {
-  validate_string($path, $repo, $version, $config_file)
+  validate_string($path, $repo, $version, $config_file, $package_name, $package_command)
   if $email {
     validate_string($email)
   }
@@ -74,12 +82,12 @@ class letsencrypt (
   }
 
   $command = $install_method ? {
-    'package' => 'letsencrypt',
+    'package' => $package_command,
     'vcs'     => "${venv_path}/bin/letsencrypt",
   }
 
   $command_init = $install_method ? {
-    'package' => 'letsencrypt',
+    'package' => $package_command,
     'vcs'     => "${path}/letsencrypt-auto",
   }
 

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -24,12 +24,16 @@
 # [*package_ensure*]
 #   The value passed to `ensure` when installing the client with the `package`
 #   method.
+# [*package_name*]
+#   Name of package to use when installing the client with the `package`
+#   method. 
 #
 class letsencrypt::install (
   $manage_install      = $letsencrypt::manage_install,
   $manage_dependencies = $letsencrypt::manage_dependencies,
   $configure_epel      = $letsencrypt::configure_epel,
   $install_method      = $letsencrypt::install_method,
+  $package_name        = $letsencrypt::package_name,
   $package_ensure      = $letsencrypt::package_ensure,
   $path                = $letsencrypt::path,
   $repo                = $letsencrypt::repo,
@@ -37,7 +41,7 @@ class letsencrypt::install (
 ) {
   validate_bool($manage_install, $manage_dependencies, $configure_epel)
   validate_re($install_method, ['^package$', '^vcs$'])
-  validate_string($path, $repo, $version)
+  validate_string($path, $repo, $version, $package_name)
 
   if $install_method == 'vcs' {
     if $manage_dependencies {
@@ -53,13 +57,13 @@ class letsencrypt::install (
       revision => $version,
     }
   } else {
-    package { 'letsencrypt':
+    package { $package_name:
       ensure => $package_ensure,
     }
 
     if $configure_epel {
       include ::epel
-      Class['epel'] -> Package['letsencrypt']
+      Class['epel'] -> Package[$package_name]
     }
   }
 }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -57,13 +57,14 @@ class letsencrypt::install (
       revision => $version,
     }
   } else {
-    package { $package_name:
+    package { 'letsencrypt':
       ensure => $package_ensure,
+      name   => $package_name,
     }
 
     if $configure_epel {
       include ::epel
-      Class['epel'] -> Package[$package_name]
+      Class['epel'] -> Package['letsencrypt']
     }
   }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -20,6 +20,8 @@ class letsencrypt::params {
     $install_method = 'package'
   } elsif $::osfamily == 'RedHat' and versioncmp($::operatingsystemmajrelease, '7') >= 0 {
     $install_method = 'package'
+  } elsif $::osfamily == 'Gentoo' {
+    $install_method = 'package'
   } else {
     $install_method = 'vcs'
   }
@@ -28,5 +30,13 @@ class letsencrypt::params {
     $configure_epel = true
   } else {
     $configure_epel = false
+  }
+  
+  if $::osfamily == 'Gentoo' {
+    $package_name = 'app-crypt/certbot'
+    $package_command = 'certbot'
+  } else {
+    $package_name = 'letsencrypt'
+    $package_command = 'letsencrypt'
   }
 }

--- a/spec/classes/letsencrypt_install_spec.rb
+++ b/spec/classes/letsencrypt_install_spec.rb
@@ -11,6 +11,7 @@ describe 'letsencrypt::install' do
       path: '/opt/letsencrypt',
       repo: 'https://github.com/letsencrypt/letsencrypt.git',
       version: 'v0.4.2',
+      package_name: 'letsencrypt',
     }
   end
   let(:additional_params) { { } }

--- a/spec/classes/letsencrypt_spec.rb
+++ b/spec/classes/letsencrypt_spec.rb
@@ -212,4 +212,19 @@ describe 'letsencrypt' do
       end
     end
   end
+  
+  context 'on Gentoo operating system' do
+    let(:facts) { { osfamily: 'Gentoo', operatingsystem: 'Gentoo', operatingsystemrelease: '4.4.6-r2', operatingsystemmajrelease: '4', path: '/usr/bin' } }
+    let(:params) { { email: 'foo@example.com' } }
+
+    describe 'with defaults' do
+      it { is_expected.to compile }
+
+      it 'should contain the correct resources' do
+        is_expected.to contain_class('letsencrypt::install').with(install_method: 'package').with(package_name: 'app-crypt/certbot')
+        is_expected.to contain_class('letsencrypt').with(package_command: 'certbot')
+      end
+    end
+  end
+  
 end

--- a/spec/classes/letsencrypt_spec.rb
+++ b/spec/classes/letsencrypt_spec.rb
@@ -223,6 +223,7 @@ describe 'letsencrypt' do
       it 'should contain the correct resources' do
         is_expected.to contain_class('letsencrypt::install').with(install_method: 'package').with(package_name: 'app-crypt/certbot')
         is_expected.to contain_class('letsencrypt').with(package_command: 'certbot')
+        is_expected.to contain_package('letsencrypt').with(name: 'app-crypt/certbot')
       end
     end
   end


### PR DESCRIPTION
This change adds package_name and package_command params
and as a bonus support for Gentoo. Test for this use case
was also created.

Name and command params default to their old values,
so change should be fully backward compatible.