### PR TITLE
Change EL7 package and command to certbot

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -16,27 +16,29 @@ class letsencrypt::params {
 
   if $::operatingsystem == 'Debian' and versioncmp($::operatingsystemrelease, '9') >= 0 {
     $install_method = 'package'
+    $package_name = 'letsencrypt'
+    $package_command = 'letsencrypt'
   } elsif $::operatingsystem == 'Ubuntu' and versioncmp($::operatingsystemrelease, '16.04') >= 0 {
     $install_method = 'package'
+    $package_name = 'letsencrypt'
+    $package_command = 'letsencrypt'
   } elsif $::osfamily == 'RedHat' and versioncmp($::operatingsystemmajrelease, '7') >= 0 {
     $install_method = 'package'
+    $package_name = 'certbot'
+    $package_command = 'certbot'
   } elsif $::osfamily == 'Gentoo' {
     $install_method = 'package'
+    $package_name = 'app-crypt/certbot'
+    $package_command = 'certbot'
   } else {
     $install_method = 'vcs'
+    $package_name = 'letsencrypt'
+    $package_command = 'letsencrypt'
   }
 
   if $::osfamily == 'RedHat' {
     $configure_epel = true
   } else {
     $configure_epel = false
-  }
-  
-  if $::osfamily == 'Gentoo' {
-    $package_name = 'app-crypt/certbot'
-    $package_command = 'certbot'
-  } else {
-    $package_name = 'letsencrypt'
-    $package_command = 'letsencrypt'
   }
 }

--- a/spec/classes/letsencrypt_spec.rb
+++ b/spec/classes/letsencrypt_spec.rb
@@ -82,7 +82,7 @@ describe 'letsencrypt' do
         end
 
         describe 'with install_method => package' do
-          let(:additional_params) { { install_method: 'package' } }
+          let(:additional_params) { { install_method: 'package', package_command: 'letsencrypt' } }
           it { is_expected.to contain_class('letsencrypt::install').with_install_method('package') }
           it { is_expected.to contain_exec('initialize letsencrypt').with_command('letsencrypt -h') }
         end
@@ -142,6 +142,8 @@ describe 'letsencrypt' do
       it 'should contain the correct resources' do
         is_expected.to contain_class('epel').that_comes_before('Package[letsencrypt]')
         is_expected.to contain_class('letsencrypt::install').with(install_method: 'package')
+        is_expected.to contain_class('letsencrypt').with(package_command: 'certbot')
+        is_expected.to contain_package('letsencrypt').with(name: 'certbot')
       end
     end
   end

--- a/spec/defines/letsencrypt_certonly_spec.rb
+++ b/spec/defines/letsencrypt_certonly_spec.rb
@@ -2,7 +2,7 @@ describe 'letsencrypt::certonly' do
   {'Debian' => '9.0', 'Ubuntu' => '16.04', 'RedHat' => '7.2'}.each do |osfamily, osversion|
     context "on #{osfamily} based operating systems" do
       let(:facts) { { osfamily: osfamily, operatingsystem: osfamily, operatingsystemrelease: osversion, operatingsystemmajrelease: osversion.split('.').first, path: '/usr/bin' } }
-      let(:pre_condition) { "class { letsencrypt: email => 'foo@example.com' }" }
+      let(:pre_condition) { "class { letsencrypt: email => 'foo@example.com', package_command => 'letsencrypt' }" }
 
       context 'with a single domain' do
         let(:title) { 'foo.example.com' }


### PR DESCRIPTION
certbot has replaced letsencrypt in EPEL7:
https://apps.fedoraproject.org/packages/certbot
https://apps.fedoraproject.org/packages/letsencrypt