### PR TITLE
Replace webroot_paths.cycle for Ruby 1.8.7 compatibility

### DIFF
--- a/manifests/certonly.pp
+++ b/manifests/certonly.pp
@@ -54,7 +54,7 @@ define letsencrypt::certonly (
 
   $command_start = "${letsencrypt_command} --agree-tos certonly -a ${plugin} "
   $command_domains = $plugin ? {
-    'webroot' => inline_template('<%= @domains.zip(@webroot_paths.cycle).map { |domain| "--webroot-path #{domain[1]} -d #{domain[0]}"}.join(" ") %>'),
+    'webroot' => inline_template('<%= @domains.zip(@webroot_paths * (@domains.size.to_f / @webroot_paths.size).ceil).map { |domain| "--webroot-path #{domain[1]} -d #{domain[0]}"}.join(" ") %>'),
     default   => inline_template('-d <%= @domains.join(" -d ")%>'),
   }
   $command_end = inline_template('<% if @additional_args %> <%= @additional_args.join(" ") %><%end%>')


### PR DESCRIPTION
Enumerable#cycle is only available in 1.9+, so change the zipping of
domains to webroot_paths with a simplified expansion of webroot_paths
to match the number of domains.

Fixes GH-28