### PR TITLE
Fix failing builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,5 +23,9 @@ matrix:
   exclude:
    - rvm: 2.2.5
      env: PUPPET_VERSION="~> 3.4"
-   - rvm: 2.3.1
+   - rvm: 2.2.5
      env: PUPPET_VERSION="~> 3.4.0"
+   - rvm: 2.3.1
+     env: PUPPET_VERSION="~> 3.4"
+   - rvm: 2.3.1
+     env: PUPPET_VERSION="~> 3.4.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,4 +28,4 @@ matrix:
    - rvm: 2.3.1
      env: PUPPET_VERSION="~> 3.4"
    - rvm: 2.3.1
-     env: PUPPET_VERSION="~> 3.4.0
+     env: PUPPET_VERSION="~> 3.4.0"

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,3 +19,9 @@ env:
   - PUPPET_VERSION="~> 4.3.0"
   - PUPPET_VERSION="~> 4"
   - PUPPET_VERSION="~> 4" STRICT_VARIABLES="yes"
+matrix:
+  exclude:
+   - rvm: 2.2.5
+     env: PUPPET_VERSION="~> 3.4"
+   - rvm: 2.3.1
+     env: PUPPET_VERSION="~> 3.4.0"

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,8 @@ rvm:
   - 1.9.3
   - 2.0.0
   - 2.1
+  - 2.2.5
+  - 2.3.1
 script: bundle exec rake test
 env:
   - PUPPET_VERSION="~> 3.4.0"

--- a/Gemfile
+++ b/Gemfile
@@ -24,6 +24,23 @@ group :test do
   gem 'puppet-lint-unquoted_string-check'
   gem 'puppet-lint-variable_contains_upcase'
   gem 'rubocop'
+
+  # Fixes specifically for the purpose of supporting Ruby and/or Puppet
+  # versions in TravisCI to allow testing for legacy versions.
+  if ENV['TRAVIS']
+    # json_pure latest versions break on old Ruby versions, so we pin the version.
+    unless ENV['TRAVIS_RUBY_VERSION'] >= '2.2'
+      gem 'json_pure', '~> 1.8'
+    end
+
+    if ENV['TRAVIS_RUBY_VERSION'] >= '2.2'
+      if ENV['PUPPET_VERSION'] == '~> 3.4'
+        # Ruby 2.2 and later removed Syck, but Puppet 3.x still requires it, so
+        # we install it here for compatibility.
+        gem 'syck'
+      end
+    end
+  end
 end
 
 group :development do

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source 'https://rubygems.org'
 group :test do
   gem 'rake'
   gem 'puppet', ENV['PUPPET_VERSION'] || ['>= 3.4', '< 5']
-  gem 'puppet-lint'
+  gem 'puppet-lint', '~> 1.0'
   gem 'rspec-puppet'
   gem 'puppet-syntax'
   gem 'puppetlabs_spec_helper'

--- a/Gemfile
+++ b/Gemfile
@@ -23,15 +23,15 @@ group :test do
   gem 'puppet-lint-undef_in_function-check'
   gem 'puppet-lint-unquoted_string-check'
   gem 'puppet-lint-variable_contains_upcase'
-  gem 'rubocop'
 
-  # Fixes specifically for the purpose of supporting Ruby and/or Puppet
-  # versions in TravisCI to allow testing for legacy versions.
-  if ENV['TRAVIS']
-    unless ENV['TRAVIS_RUBY_VERSION'] >= '2.2'
-      gem 'json_pure', '~> 1.8'
-      gem 'rubocop', '~> 0.39.0'
-    end
+  if ENV['TRAVIS_RUBY_VERSION'] < '2.2'
+    gem 'json_pure', '~> 1.8'
+  end
+
+  if ENV['TRAVIS_RUBY_VERSION'] < '2.0'
+    gem 'rubocop', '~> 0.39.0'
+  else
+    gem 'rubocop'
   end
 end
 

--- a/Gemfile
+++ b/Gemfile
@@ -28,17 +28,9 @@ group :test do
   # Fixes specifically for the purpose of supporting Ruby and/or Puppet
   # versions in TravisCI to allow testing for legacy versions.
   if ENV['TRAVIS']
-    # json_pure latest versions break on old Ruby versions, so we pin the version.
     unless ENV['TRAVIS_RUBY_VERSION'] >= '2.2'
       gem 'json_pure', '~> 1.8'
-    end
-
-    if ENV['TRAVIS_RUBY_VERSION'] >= '2.2'
-      if ENV['PUPPET_VERSION'] == '~> 3.4'
-        # Ruby 2.2 and later removed Syck, but Puppet 3.x still requires it, so
-        # we install it here for compatibility.
-        gem 'syck'
-      end
+      gem 'rubocop', '~> 0.39.0'
     end
   end
 end

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -77,7 +77,7 @@ class letsencrypt (
   validate_re($install_method, ['^package$', '^vcs$'])
 
   if $manage_install {
-    contain letsencrypt::install
+    contain letsencrypt::install # lint:ignore:relative_classname_inclusion
     Class['letsencrypt::install'] ~> Exec['initialize letsencrypt']
   }
 
@@ -92,7 +92,7 @@ class letsencrypt (
   }
 
   if $manage_config {
-    contain letsencrypt::config
+    contain letsencrypt::config # lint:ignore:relative_classname_inclusion
     Class['letsencrypt::config'] -> Exec['initialize letsencrypt']
   }
 


### PR DESCRIPTION
This PR:
- Fixes the builds failing on older Ruby/Puppet versions on TravisCI.
- Adds Ruby 2.2 and 2.3 builds to TravisCI.
- Pins puppet-lint to avoid broken dependency chain as per db174a6
- Disable false alarm from linter due to `contain` keyword as per 22bf3da
