### PR TITLE
Prevent cron spam

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,8 +84,8 @@ letsencrypt::certonly { 'foo':
 
 To request a certificate using the `webroot` plugin, the paths to the webroots
 for all domains must be given through `webroot_paths`. If `domains` and
-`webroot_paths` are not the same length, `webroot_paths` will cycle to make up
-the difference.
+`webroot_paths` are not the same length, the last `webroot_paths` element will
+be used for all subsequent domains.
 
 ```puppet
 letsencrypt::certonly { 'foo':

--- a/manifests/certonly.pp
+++ b/manifests/certonly.pp
@@ -71,7 +71,7 @@ define letsencrypt::certonly (
   }
 
   if $manage_cron {
-    $renewcommand = "${command_start}--keep-until-expiring ${command_domains}${command_end}"
+    $renewcommand = "${command_start}--keep-until-expiring --quiet ${command_domains}${command_end}"
     if $cron_success_command {
       $cron_cmd = "${renewcommand} && (${cron_success_command})"
     } else {

--- a/manifests/certonly.pp
+++ b/manifests/certonly.pp
@@ -12,8 +12,8 @@
 # [*webroot_paths*]
 #   An array of webroot paths for the domains in `domains`.
 #   Required if using `plugin => 'webroot'`. If `domains` and
-#   `webroot_paths` are not the same length, `webroot_paths`
-#   will cycle to make up the difference.
+#   `webroot_paths` are not the same length, the last `webroot_paths`
+#   element will be used for all subsequent domains.
 # [*letsencrypt_command*]
 #   Command to run letsencrypt
 # [*additional_args*]
@@ -54,7 +54,7 @@ define letsencrypt::certonly (
 
   $command_start = "${letsencrypt_command} --agree-tos certonly -a ${plugin} "
   $command_domains = $plugin ? {
-    'webroot' => inline_template('<%= @domains.zip(@webroot_paths.cycle).map { |domain| "--webroot-path #{domain[1]} -d #{domain[0]}"}.join(" ") %>'),
+    'webroot' => inline_template('<%= @domains.zip(@webroot_paths).map { |domain| "#{"--webroot-path #{domain[1]} " if domain[1]}-d #{domain[0]}"}.join(" ") %>'),
     default   => inline_template('-d <%= @domains.join(" -d ")%>'),
   }
   $command_end = inline_template('<% if @additional_args %> <%= @additional_args.join(" ") %><%end%>')

--- a/spec/defines/letsencrypt_certonly_spec.rb
+++ b/spec/defines/letsencrypt_certonly_spec.rb
@@ -43,7 +43,7 @@ describe 'letsencrypt::certonly' do
         let(:params) { { domains: ['foo.example.com', 'bar.example.com'],
                          plugin: 'webroot',
                          webroot_paths: ['/var/www/foo'] } }
-        it { is_expected.to contain_exec('letsencrypt certonly foo').with_command 'letsencrypt --agree-tos certonly -a webroot --webroot-path /var/www/foo -d foo.example.com --webroot-path /var/www/foo -d bar.example.com' }
+        it { is_expected.to contain_exec('letsencrypt certonly foo').with_command 'letsencrypt --agree-tos certonly -a webroot --webroot-path /var/www/foo -d foo.example.com -d bar.example.com' }
       end
 
       context 'with webroot plugin and no webroot_paths' do


### PR DESCRIPTION
Added `--quiet` argument to certbot. This implies `--non-interactive` so immediately stops getting exceptions trying to load dialog boxes, but also ensures that we don't send an email every day saying no certs for renewal.

`--quiet` will still result in output if certbot outputs anything on STDERR.